### PR TITLE
Fix code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/public/interests/music/fm/playing/js.js
+++ b/public/interests/music/fm/playing/js.js
@@ -75,7 +75,7 @@ function confirmUser() {
 	user = document.getElementById('username').value;
 	document.getElementById('enter-name').style.display = 'none';
 	document.getElementById('controls').style.display = 'block';
-	document.getElementById('show-username').innerHTML = user;
+	document.getElementById('show-username').textContent = user;
 	getNowPlaying();
 }
 function setBgButtonStatus(...buttons) {

--- a/public/more/archive/blog/concepts/2023/ai.html
+++ b/public/more/archive/blog/concepts/2023/ai.html
@@ -286,14 +286,22 @@
                 document.getElementById(`m${newBoy}`).style.display = "block";
                 conductor = newBoy;
             }
+            function escapeHtml(unsafe) {
+                return unsafe
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#039;");
+            }
             function internalGenerate() {
-                var pageNumber = document.getElementById("danumber").value;
-                var poopCont = document.getElementById("pagecont").value;
-                var linkNo1 = document.getElementById("link1").value;
-                var linkNo2 = document.getElementById("link2").value;
-                var linkNo3 = document.getElementById("link3").value;
-                var linkNo4 = document.getElementById("link4").value;
-                var linkNo5 = document.getElementById("link5").value;
+                var pageNumber = escapeHtml(document.getElementById("danumber").value);
+                var poopCont = escapeHtml(document.getElementById("pagecont").value);
+                var linkNo1 = escapeHtml(document.getElementById("link1").value);
+                var linkNo2 = escapeHtml(document.getElementById("link2").value);
+                var linkNo3 = escapeHtml(document.getElementById("link3").value);
+                var linkNo4 = escapeHtml(document.getElementById("link4").value);
+                var linkNo5 = escapeHtml(document.getElementById("link5").value);
                 let newGen = `&ltdiv class="msg" id="m${pageNumber}"&gt;<br>&lt;p&gt;&lt;img src="ai/neut.png"&gt;${poopCont}&lt;/p&gt;<br>&lt;ul id="l${pageNumber}"&gt;<br>&lt;li&gt;&lt;a class="wip"&gt;${linkNo1}&lt;/a&gt;&lt;/li&gt;<br>&lt;li&gt;&lt;a class="wip"&gt;${linkNo2}&lt;/a&gt;&lt;/li&gt;<br>&lt;li&gt;&lt;a class="wip"&gt;${linkNo3}&lt;/a&gt;&lt;/li&gt;<br>&lt;li&gt;&lt;a class="wip"&gt;${linkNo4}&lt;/a&gt;&lt;/li&gt;<br>&lt;li&gt;&lt;a class="wip"&gt;${linkNo5}&lt;/a&gt;&lt;/li&gt;<br>&lt;/ul&gt;<br>&lt;/div&gt;`;
                 document.getElementById("outputhtml").innerHTML = newGen;
             }


### PR DESCRIPTION
Fixes [https://github.com/telnettrauma/wiichicken-neocities/security/code-scanning/11](https://github.com/telnettrauma/wiichicken-neocities/security/code-scanning/11)

To fix the problem, we need to ensure that any user input is properly escaped before being inserted into the HTML. This can be achieved by using a function to escape HTML special characters. We will create a function to escape the user input and then use this function before setting the `innerHTML` property.

1. Create a function to escape HTML special characters.
2. Use this function to escape the user input before assigning it to `newGen`.
3. Replace the direct assignment to `innerHTML` with the escaped content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
